### PR TITLE
Use the bitnami/minideb image as base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9
+FROM bitnami/minideb:stretch
 MAINTAINER DST Academy <support@dst.academy>
 
 # Set build arguments.


### PR DESCRIPTION
Recently I [learned](https://dzone.com/articles/minideb-a-minimalist-debian-based-docker-image) about the [bitnami/minideb](https://github.com/bitnami/minideb) image and after some testing it seems that we can use it as base image. The `dstacademy/steamcmd` image's size shrinks from 191MB to 142MB.